### PR TITLE
feat: display IT request category list

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -19,6 +19,9 @@ export async function checkSystem(): Promise<SystemStatus> {
   const healthRes = await fetch(`${API_URL}/api/health`);
   if (!healthRes.ok) throw new Error("Health check failed");
 
-  // TODO(Issue 4): fetch categories from /api/categories
-  return { online: true, categories: [] };
+  const categoriesRes = await fetch(`${API_URL}/api/categories`);
+  if (!categoriesRes.ok) throw new Error("Categories fetch failed");
+  const categories: Category[] = await categoriesRes.json();
+
+  return { online: true, categories };
 }

--- a/client/tests/lab-01/App.test.tsx
+++ b/client/tests/lab-01/App.test.tsx
@@ -1,6 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import App from "../../src/App.js";
+
+import * as api from "../../src/api.js";
+import { fireEvent, waitFor } from "@testing-library/react";
 
 describe("App", () => {
   // WORKED EXAMPLE — provided for you.
@@ -12,6 +15,38 @@ describe("App", () => {
   // Issue 4 — write these yourself. Hint: mock the api module with
   // vi.spyOn(api, "checkSystem").mockResolvedValue(...) / .mockRejectedValue(...)
   // then click the button and assert the Online list / Offline message.
-  it.todo("shows Online and the seeded categories on success");
-  it.todo("shows an Offline error message when the API is unavailable");
+  it("shows Online and the seeded categories on success", async () => {
+    const mockCategories = [
+      { id: 1, name: "Account and Access" },
+      { id: 2, name: "Hardware" },
+    ];
+    vi.spyOn(api, "checkSystem").mockResolvedValue({ online: true, categories: mockCategories });
+
+    render(<App />);
+    const btn = screen.getByRole("button", { name: /Check System/i });
+    fireEvent.click(btn);
+
+    expect(screen.getAllByText(/⏳ Loading…/i).length).toBeGreaterThan(0);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Online/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Account and Access")).toBeInTheDocument();
+    expect(screen.getByText("Hardware")).toBeInTheDocument();
+  });
+
+  it("shows an Offline error message when the API is unavailable", async () => {
+    vi.spyOn(api, "checkSystem").mockRejectedValue(new Error("Network Error"));
+
+    render(<App />);
+    const btn = screen.getByRole("button", { name: /Check System/i });
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Offline/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/Unable to connect to TokTickIT API/i)).toBeInTheDocument();
+  });
 });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -3,7 +3,7 @@ import cors from "cors";
 import { getPrisma } from "./prisma.js";
 // getPrisma() is your lazy database handle. Call it INSIDE a route when you
 // need the DB (Issue 4). It is intentionally unused until then.
-void getPrisma;
+
 
 // The Express app is exported separately from app.listen() (see index.ts) so
 // Supertest can import `app` without opening a port. Do not merge these files.
@@ -27,7 +27,18 @@ app.get("/api/health", (_req: Request, res: Response) => {
 //   -> read categories from PostgreSQL via getPrisma().category.findMany(...)
 //   -> return each { id, name } in a predictable (id) order
 //   -> on failure, respond 500 with a safe message (no internal details)
-// TODO(Issue 4): implement the route here.
-// ---------------------------------------------------------------------------
+app.get("/api/categories", async (_req: Request, res: Response) => {
+  try {
+    const prisma = getPrisma();
+    const categories = await prisma.category.findMany({
+      select: { id: true, name: true },
+      orderBy: { id: 'asc' }
+    });
+    res.json(categories);
+  } catch (error) {
+    console.error("Failed to fetch categories:", error);
+    res.status(500).json({ error: "Internal Server Error" });
+  }
+});
 
 export default app;

--- a/server/tests/lab-01/categories.test.ts
+++ b/server/tests/lab-01/categories.test.ts
@@ -1,15 +1,23 @@
 import { describe, it, expect } from "vitest";
 import request from "supertest";
 import { app } from "../../src/app.js";
-void request; void app;
+
 
 // Issue 4 — write this test yourself, using health.test.ts as the pattern.
 // Requires the DB to be migrated and seeded first.
 // It should assert: GET /api/categories returns 200 and the four seeded
 // category names in id order.
-describe.todo("GET /api/categories", () => {
-  it.todo("returns the four seeded categories in id order", async () => {
-    // TODO(Issue 4): implement this assertion.
-    expect(true).toBe(true);
+describe("GET /api/categories", () => {
+  it("returns the four seeded categories in id order", async () => {
+    const response = await request(app).get("/api/categories");
+    
+    expect(response.status).toBe(200);
+    expect(response.body).toBeInstanceOf(Array);
+    expect(response.body).toHaveLength(4);
+    
+    expect(response.body[0].name).toBe("Account and Access");
+    expect(response.body[1].name).toBe("Hardware");
+    expect(response.body[2].name).toBe("Software");
+    expect(response.body[3].name).toBe("Network");
   });
 });


### PR DESCRIPTION
## Summary
Display the IT request category list from the database on the frontend.

## Changes
- Implemented `GET /api/categories` endpoint in `app.ts` to return categories from Prisma ordered by `id`.
- Added Supertest assertions for the categories endpoint in `categories.test.ts`.
- Updated `api.ts` `checkSystem` function to fetch from `/api/categories` along with `/api/health`.
- Updated `App.test.tsx` to include UI Vitest tests that verify loading, success (with seeded categories), and offline error states.
- All backend and frontend tests are passing.

## Acceptance Criteria
- [x] GET /api/categories returns HTTP 200 with JSON categories array in id order
- [x] A Supertest test verifies the categories endpoint
- [x] The React page displays the categories fetched from the real API call
- [x] UI Vitest tests verify the successful and offline states

Closes #4
