### PR TITLE
feat(lab2): implement ticket detail & attachments lifecycle with soft-removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,6 @@ build/
 server/prisma/*.db
 # logs & OS
 *.log
-.DS_Store
+# uploads
+server/uploads/*
+!server/uploads/.gitkeep

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -155,3 +155,91 @@ export async function fetchTickets(filters: TicketQueryFilters): Promise<TicketL
   return res.json();
 }
 
+// ---------------------------------------------------------------------------
+// Lab 2 — Issue 5: Ticket Detail & Attachment Types & Functions
+// ---------------------------------------------------------------------------
+export interface AttachmentItem {
+  id: number;
+  originalName: string;
+  sizeBytes: number;
+  mimeType: string;
+  active: boolean;
+  removalReason?: string | null;
+  removedAt?: string | null;
+  createdAt: string;
+}
+
+export interface TicketDetail {
+  id: number;
+  ticketNumber: string;
+  ticketDate: string;
+  summary: string;
+  description: string;
+  priority: string;
+  status: string;
+  requester: { id: number; name: string; email: string };
+  category: { id: number; name: string };
+  relatedSystem: { id: number; name: string };
+  attachments: AttachmentItem[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export async function fetchTicketDetail(
+  ticketId: number,
+  requesterId: number
+): Promise<TicketDetail> {
+  const res = await fetch(`${API_URL}/api/tickets/${ticketId}?requesterId=${requesterId}`);
+  if (!res.ok) {
+    const errorBody = await res.json().catch(() => ({}));
+    throw new Error(errorBody.error || "Failed to fetch ticket detail");
+  }
+  return res.json();
+}
+
+export async function uploadAttachment(
+  ticketId: number,
+  requesterId: number,
+  file: File
+): Promise<AttachmentItem> {
+  const formData = new FormData();
+  formData.append("requesterId", String(requesterId));
+  formData.append("file", file);
+
+  const res = await fetch(`${API_URL}/api/tickets/${ticketId}/attachments`, {
+    method: "POST",
+    body: formData,
+  });
+
+  if (!res.ok) {
+    const errorBody = await res.json().catch(() => ({}));
+    throw new Error(errorBody.error || "Failed to upload attachment");
+  }
+  return res.json();
+}
+
+export function getAttachmentDownloadUrl(
+  attachmentId: number,
+  requesterId: number
+): string {
+  return `${API_URL}/api/attachments/${attachmentId}/download?requesterId=${requesterId}`;
+}
+
+export async function removeAttachment(
+  attachmentId: number,
+  requesterId: number,
+  reason: string
+): Promise<AttachmentItem> {
+  const res = await fetch(`${API_URL}/api/attachments/${attachmentId}/remove`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ requesterId, reason }),
+  });
+
+  if (!res.ok) {
+    const errorBody = await res.json().catch(() => ({}));
+    throw new Error(errorBody.error || "Failed to remove attachment");
+  }
+  return res.json();
+}
+

--- a/client/src/components/AppShell.tsx
+++ b/client/src/components/AppShell.tsx
@@ -3,12 +3,14 @@ import { useRequester } from "../context/RequesterContext.js";
 import { checkSystem, Category } from "../api.js";
 import CreateTicket from "./CreateTicket.js";
 import MyTickets from "./MyTickets.js";
+import TicketDetail from "./TicketDetail.js";
 
-type Tab = "my-tickets" | "create-ticket" | "system-status";
+type Tab = "my-tickets" | "create-ticket" | "system-status" | "ticket-detail";
 
 export default function AppShell() {
   const { requester, clearRequester } = useRequester();
   const [activeTab, setActiveTab] = useState<Tab>("system-status");
+  const [selectedTicketId, setSelectedTicketId] = useState<number | null>(null);
 
   // Lab 1 state preservation for system check
   const [systemState, setSystemState] = useState<"idle" | "loading" | "success" | "error">("idle");
@@ -41,22 +43,31 @@ export default function AppShell() {
           <nav className="d-flex align-items-center gap-1">
             <button
               type="button"
-              className={`zen-nav-btn ${activeTab === "my-tickets" ? "active" : ""}`}
-              onClick={() => setActiveTab("my-tickets")}
+              className={`zen-nav-btn ${activeTab === "my-tickets" || activeTab === "ticket-detail" ? "active" : ""}`}
+              onClick={() => {
+                setSelectedTicketId(null);
+                setActiveTab("my-tickets");
+              }}
             >
               📋 My Tickets
             </button>
             <button
               type="button"
               className={`zen-nav-btn ${activeTab === "create-ticket" ? "active" : ""}`}
-              onClick={() => setActiveTab("create-ticket")}
+              onClick={() => {
+                setSelectedTicketId(null);
+                setActiveTab("create-ticket");
+              }}
             >
               ➕ Create Ticket
             </button>
             <button
               type="button"
               className={`zen-nav-btn ${activeTab === "system-status" ? "active" : ""}`}
-              onClick={() => setActiveTab("system-status")}
+              onClick={() => {
+                setSelectedTicketId(null);
+                setActiveTab("system-status");
+              }}
             >
               ⚡ System Status
             </button>
@@ -88,7 +99,23 @@ export default function AppShell() {
       {/* Main Content Area */}
       <main className="container py-4 flex-grow-1" style={{ maxWidth: 960 }}>
         {activeTab === "my-tickets" && (
-          <MyTickets onNavigateToCreate={() => setActiveTab("create-ticket")} />
+          <MyTickets
+            onNavigateToCreate={() => setActiveTab("create-ticket")}
+            onSelectTicket={(ticketId) => {
+              setSelectedTicketId(ticketId);
+              setActiveTab("ticket-detail");
+            }}
+          />
+        )}
+
+        {activeTab === "ticket-detail" && selectedTicketId && (
+          <TicketDetail
+            ticketId={selectedTicketId}
+            onBack={() => {
+              setSelectedTicketId(null);
+              setActiveTab("my-tickets");
+            }}
+          />
         )}
 
         {activeTab === "create-ticket" && (

--- a/client/src/components/TicketDetail.tsx
+++ b/client/src/components/TicketDetail.tsx
@@ -1,0 +1,543 @@
+import React, { useState, useEffect, useCallback, useRef } from "react";
+import { useRequester } from "../context/RequesterContext.js";
+import {
+  fetchTicketDetail,
+  uploadAttachment,
+  getAttachmentDownloadUrl,
+  removeAttachment,
+  TicketDetail as ITicketDetail,
+  AttachmentItem,
+} from "../api.js";
+
+interface Props {
+  ticketId: number;
+  onBack: () => void;
+}
+
+function getPriorityBadgeClass(priority: string): string {
+  switch (priority) {
+    case "Critical":
+      return "badge-priority-critical";
+    case "High":
+      return "badge-priority-high";
+    case "Medium":
+      return "badge-priority-medium";
+    case "Low":
+    default:
+      return "badge-priority-low";
+  }
+}
+
+function getStatusBadgeClass(status: string): string {
+  switch (status) {
+    case "In Progress":
+      return "badge-status-inprogress";
+    case "Resolved":
+      return "badge-status-resolved";
+    case "New":
+    default:
+      return "badge-status-new";
+  }
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 Bytes";
+  const k = 1024;
+  const sizes = ["Bytes", "KB", "MB", "GB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + " " + sizes[i];
+}
+
+function formatDate(isoString: string): string {
+  if (!isoString) return "—";
+  const d = new Date(isoString);
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+const ALLOWED_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "application/pdf",
+];
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
+
+export default function TicketDetail({ ticketId, onBack }: Props) {
+  const { requester } = useRequester();
+
+  const [ticket, setTicket] = useState<ITicketDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  // Upload state
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState("");
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Soft-remove modal state
+  const [targetAttachment, setTargetAttachment] = useState<AttachmentItem | null>(null);
+  const [removalReason, setRemovalReason] = useState("");
+  const [removalError, setRemovalError] = useState("");
+  const [removing, setRemoving] = useState(false);
+
+  // Load ticket details
+  const loadTicket = useCallback(async () => {
+    if (!requester) return;
+    setLoading(true);
+    setError("");
+    try {
+      const data = await fetchTicketDetail(ticketId, requester.id);
+      setTicket(data);
+    } catch (err: any) {
+      setError(err.message || "Failed to load ticket details");
+    } finally {
+      setLoading(false);
+    }
+  }, [ticketId, requester]);
+
+  useEffect(() => {
+    loadTicket();
+  }, [loadTicket]);
+
+  // Handle file upload
+  async function handleFileSelected(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file || !requester || !ticket) return;
+
+    setUploadError("");
+
+    // Client-side validation
+    if (!ALLOWED_MIME_TYPES.includes(file.type)) {
+      setUploadError("Unsupported file type. Permitted: JPG, PNG, WEBP, PDF.");
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      return;
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      setUploadError("File size exceeds 5MB limit.");
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      return;
+    }
+
+    const activeCount = ticket.attachments.filter((a) => a.active).length;
+    if (activeCount >= 5) {
+      setUploadError("Maximum 5 active attachments allowed per ticket.");
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      return;
+    }
+
+    setUploading(true);
+    try {
+      const newAttachment = await uploadAttachment(ticket.id, requester.id, file);
+      setTicket((prev) =>
+        prev
+          ? {
+              ...prev,
+              attachments: [...prev.attachments, newAttachment],
+            }
+          : null
+      );
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    } catch (err: any) {
+      setUploadError(err.message || "Failed to upload attachment");
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  // Handle soft removal submit
+  async function handleConfirmRemoval() {
+    if (!requester || !targetAttachment) return;
+
+    const trimmed = removalReason.trim();
+    if (trimmed.length < 5) {
+      setRemovalError("Removal reason must be at least 5 characters.");
+      return;
+    }
+
+    setRemoving(true);
+    setRemovalError("");
+    try {
+      const updated = await removeAttachment(targetAttachment.id, requester.id, trimmed);
+      setTicket((prev) =>
+        prev
+          ? {
+              ...prev,
+              attachments: prev.attachments.map((a) =>
+                a.id === updated.id
+                  ? {
+                      ...a,
+                      active: false,
+                      removalReason: updated.removalReason,
+                      removedAt: updated.removedAt,
+                    }
+                  : a
+              ),
+            }
+          : null
+      );
+      // Close modal
+      setTargetAttachment(null);
+      setRemovalReason("");
+    } catch (err: any) {
+      setRemovalError(err.message || "Failed to remove attachment");
+    } finally {
+      setRemoving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="zen-card p-5 text-center my-4" data-testid="ticket-detail-loading">
+        <div className="spinner-border text-success mb-3" role="status">
+          <span className="visually-hidden">Loading ticket details...</span>
+        </div>
+        <p className="text-muted mb-0">Loading ticket details...</p>
+      </div>
+    );
+  }
+
+  if (error || !ticket) {
+    return (
+      <div className="zen-card p-5 text-center my-4" data-testid="ticket-detail-error">
+        <div className="display-6 mb-3">⚠️</div>
+        <h3 className="h5 fw-bold mb-2">Ticket Not Found or Unauthorized</h3>
+        <p className="text-muted mb-4" style={{ maxWidth: 450, margin: "0 auto" }}>
+          {error || "The requested ticket does not exist or you do not have permission to view it."}
+        </p>
+        <button type="button" className="btn btn-zen-primary" onClick={onBack}>
+          ← Back to My Tickets
+        </button>
+      </div>
+    );
+  }
+
+  const activeAttachments = ticket.attachments.filter((a) => a.active);
+  const activeCount = activeAttachments.length;
+
+  return (
+    <div className="d-flex flex-column gap-4" data-testid="ticket-detail-view">
+      {/* Top Action Bar */}
+      <div className="d-flex justify-content-between align-items-center">
+        <button
+          type="button"
+          className="btn btn-zen-secondary btn-sm d-inline-flex align-items-center gap-1"
+          onClick={onBack}
+        >
+          <span>←</span> Back to My Tickets
+        </button>
+
+        <div className="d-flex gap-2 align-items-center">
+          <span className={`badge ${getPriorityBadgeClass(ticket.priority)}`}>
+            {ticket.priority} Priority
+          </span>
+          <span className={`badge ${getStatusBadgeClass(ticket.status)}`}>
+            {ticket.status}
+          </span>
+        </div>
+      </div>
+
+      {/* Main Ticket Information Card */}
+      <div className="zen-card p-4">
+        <div className="d-flex flex-wrap justify-content-between align-items-start gap-2 border-bottom pb-3 mb-3">
+          <div>
+            <span
+              className="fw-bold font-monospace fs-5"
+              style={{ color: "var(--zen-primary)" }}
+              data-testid="ticket-number"
+            >
+              {ticket.ticketNumber}
+            </span>
+            <h2 className="h4 fw-bold mt-1 mb-0" style={{ color: "var(--zen-text-primary)" }}>
+              {ticket.summary}
+            </h2>
+          </div>
+          <div className="text-muted small text-end">
+            <div>Submitted on</div>
+            <div className="fw-semibold">{formatDate(ticket.ticketDate || ticket.createdAt)}</div>
+          </div>
+        </div>
+
+        {/* Metadata Grid */}
+        <div className="row g-3 mb-4 bg-light p-3 rounded-3 border">
+          <div className="col-12 col-sm-6 col-md-3">
+            <span className="text-muted small d-block">Category</span>
+            <span className="fw-semibold" style={{ color: "var(--zen-text-primary)" }}>
+              {ticket.category.name}
+            </span>
+          </div>
+
+          <div className="col-12 col-sm-6 col-md-3">
+            <span className="text-muted small d-block">Related System</span>
+            <span className="fw-semibold" style={{ color: "var(--zen-text-primary)" }}>
+              {ticket.relatedSystem.name}
+            </span>
+          </div>
+
+          <div className="col-12 col-sm-6 col-md-3">
+            <span className="text-muted small d-block">Requester</span>
+            <span className="fw-semibold" style={{ color: "var(--zen-text-primary)" }}>
+              {ticket.requester.name}
+            </span>
+          </div>
+
+          <div className="col-12 col-sm-6 col-md-3">
+            <span className="text-muted small d-block">Contact Email</span>
+            <span className="text-muted small text-truncate d-block">
+              {ticket.requester.email}
+            </span>
+          </div>
+        </div>
+
+        {/* Description */}
+        <div className="mb-2">
+          <h3 className="h6 fw-bold mb-2" style={{ color: "var(--zen-text-primary)" }}>
+            Description
+          </h3>
+          <div
+            className="p-3 rounded-3 border"
+            style={{
+              backgroundColor: "var(--zen-read-only)",
+              whiteSpace: "pre-wrap",
+              lineHeight: 1.6,
+              color: "var(--zen-text-primary)",
+            }}
+          >
+            {ticket.description}
+          </div>
+        </div>
+      </div>
+
+      {/* Attachments Section */}
+      <div className="zen-card p-4">
+        <div className="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
+          <div>
+            <h3 className="h5 fw-bold m-0" style={{ color: "var(--zen-text-primary)" }}>
+              Attachments
+            </h3>
+            <span className="text-muted small">
+              ({activeCount} / 5 active attachments)
+            </span>
+          </div>
+
+          {/* Upload Button & Input */}
+          {activeCount < 5 ? (
+            <div className="d-flex align-items-center gap-2">
+              <input
+                ref={fileInputRef}
+                type="file"
+                id="attachment-file-input"
+                className="d-none"
+                accept=".jpg,.jpeg,.png,.webp,.pdf"
+                onChange={handleFileSelected}
+                disabled={uploading}
+              />
+              <button
+                type="button"
+                className="btn btn-zen-primary btn-sm"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={uploading}
+              >
+                {uploading ? "⏳ Uploading..." : "➕ Add Attachment"}
+              </button>
+            </div>
+          ) : (
+            <span className="badge bg-warning text-dark border">
+              Maximum 5 active attachments reached
+            </span>
+          )}
+        </div>
+
+        {/* Upload Error Banner */}
+        {uploadError && (
+          <div className="alert alert-danger py-2 small mb-3" role="alert">
+            {uploadError}
+          </div>
+        )}
+
+        {/* Attachment List */}
+        {ticket.attachments.length === 0 ? (
+          <div className="text-center py-4 text-muted border rounded-3 bg-light">
+            <p className="mb-0 small">No attachments uploaded for this ticket.</p>
+          </div>
+        ) : (
+          <div className="d-flex flex-column gap-2">
+            {ticket.attachments.map((att) => {
+              const isPdf = att.mimeType === "application/pdf" || att.originalName.endsWith(".pdf");
+              const isImage = att.mimeType.startsWith("image/");
+              const icon = isPdf ? "📄" : isImage ? "🖼️" : "📎";
+
+              return (
+                <div
+                  key={att.id}
+                  className={`p-3 border rounded-3 d-flex flex-wrap justify-content-between align-items-center gap-2 ${
+                    att.active ? "bg-white" : "bg-light"
+                  }`}
+                  data-testid={`attachment-item-${att.id}`}
+                >
+                  {/* File Info */}
+                  <div className="d-flex align-items-center gap-3">
+                    <span style={{ fontSize: "1.5rem" }}>{icon}</span>
+                    <div>
+                      <div className="d-flex align-items-center gap-2">
+                        <span
+                          className={`fw-semibold small ${
+                            att.active ? "" : "text-muted text-decoration-line-through"
+                          }`}
+                        >
+                          {att.originalName}
+                        </span>
+                        {!att.active && (
+                          <span className="badge bg-danger-subtle text-danger border border-danger-subtle small">
+                            Removed
+                          </span>
+                        )}
+                      </div>
+                      <div className="text-muted small" style={{ fontSize: "0.8rem" }}>
+                        {formatBytes(att.sizeBytes)} • Uploaded {formatDate(att.createdAt)}
+                      </div>
+
+                      {/* Removal Audit Info */}
+                      {!att.active && att.removalReason && (
+                        <div
+                          className="mt-1 text-danger small p-2 rounded"
+                          style={{ backgroundColor: "var(--zen-danger-bg)", fontSize: "0.8rem" }}
+                        >
+                          <strong>Removal Reason:</strong> {att.removalReason}
+                          {att.removedAt && (
+                            <span className="text-muted ms-2">
+                              ({formatDate(att.removedAt)})
+                            </span>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* Actions */}
+                  <div className="d-flex align-items-center gap-2">
+                    {att.active ? (
+                      <>
+                        <a
+                          href={getAttachmentDownloadUrl(att.id, requester!.id)}
+                          download={att.originalName}
+                          className="btn btn-zen-secondary btn-sm"
+                          data-testid={`download-attachment-${att.id}`}
+                        >
+                          ⬇️ Download
+                        </a>
+                        <button
+                          type="button"
+                          className="btn btn-outline-danger btn-sm"
+                          onClick={() => {
+                            setTargetAttachment(att);
+                            setRemovalReason("");
+                            setRemovalError("");
+                          }}
+                          data-testid={`remove-attachment-${att.id}`}
+                        >
+                          🗑️ Remove
+                        </button>
+                      </>
+                    ) : (
+                      <span className="text-muted small fst-italic">
+                        Download unavailable
+                      </span>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Soft-Removal Confirmation Modal */}
+      {targetAttachment && (
+        <div
+          className="modal d-block"
+          tabIndex={-1}
+          style={{ backgroundColor: "rgba(0, 0, 0, 0.5)" }}
+          role="dialog"
+          aria-modal="true"
+        >
+          <div className="modal-dialog modal-dialog-centered">
+            <div className="modal-content shadow-lg border-0">
+              <div className="modal-header border-bottom">
+                <h5 className="modal-title fw-bold" style={{ color: "var(--zen-text-primary)" }}>
+                  Remove Attachment
+                </h5>
+                <button
+                  type="button"
+                  className="btn-close"
+                  aria-label="Close"
+                  onClick={() => setTargetAttachment(null)}
+                  disabled={removing}
+                />
+              </div>
+
+              <div className="modal-body">
+                <p className="small text-muted mb-3">
+                  You are about to remove <strong>{targetAttachment.originalName}</strong>. This
+                  action soft-removes the file, preserves an audit trail, and disables future
+                  downloads.
+                </p>
+
+                <div className="mb-3">
+                  <label htmlFor="removal-reason-input" className="form-label fw-semibold small">
+                    Reason for Removal <span className="text-danger">*</span>
+                  </label>
+                  <textarea
+                    id="removal-reason-input"
+                    className="form-control"
+                    rows={3}
+                    placeholder="Enter at least 5 characters explaining why this file is removed..."
+                    value={removalReason}
+                    onChange={(e) => setRemovalReason(e.target.value)}
+                    disabled={removing}
+                  />
+                  <div className="d-flex justify-content-between mt-1 text-muted small">
+                    <span>Minimum 5 characters required</span>
+                    <span>{removalReason.trim().length} chars</span>
+                  </div>
+                </div>
+
+                {removalError && (
+                  <div className="alert alert-danger py-2 small" role="alert">
+                    {removalError}
+                  </div>
+                )}
+              </div>
+
+              <div className="modal-footer border-top">
+                <button
+                  type="button"
+                  className="btn btn-secondary btn-sm"
+                  onClick={() => setTargetAttachment(null)}
+                  disabled={removing}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-danger btn-sm"
+                  onClick={handleConfirmRemoval}
+                  disabled={removing || removalReason.trim().length < 5}
+                >
+                  {removing ? "Removing..." : "Confirm Removal"}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/tests/lab-02/TicketDetail.test.tsx
+++ b/client/tests/lab-02/TicketDetail.test.tsx
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+import { RequesterProvider } from "../../src/context/RequesterContext.js";
+import TicketDetail from "../../src/components/TicketDetail.js";
+import * as api from "../../src/api.js";
+
+vi.mock("../../src/api.js", async () => {
+  const actual = await vi.importActual("../../src/api.js");
+  return {
+    ...actual,
+    fetchTicketDetail: vi.fn(),
+    uploadAttachment: vi.fn(),
+    removeAttachment: vi.fn(),
+    getAttachmentDownloadUrl: vi.fn(
+      (attId, reqId) => `http://localhost:3000/api/attachments/${attId}/download?requesterId=${reqId}`
+    ),
+  };
+});
+
+const mockTicketData: api.TicketDetail = {
+  id: 10,
+  ticketNumber: "TKT-2026-000010",
+  ticketDate: "2026-09-04T10:30:00.000Z",
+  summary: "VPN Connection drops every 15 minutes",
+  description: "When working from home, the Cisco AnyConnect client disconnects abruptly.",
+  priority: "High",
+  status: "New",
+  requester: { id: 1, name: "Jennifer Anderson", email: "jennifer.anderson@example.com" },
+  category: { id: 4, name: "Network" },
+  relatedSystem: { id: 3, name: "VPN" },
+  attachments: [
+    {
+      id: 101,
+      originalName: "vpn-log.pdf",
+      sizeBytes: 204800,
+      mimeType: "application/pdf",
+      active: true,
+      removalReason: null,
+      removedAt: null,
+      createdAt: "2026-09-04T10:35:00.000Z",
+    },
+  ],
+  createdAt: "2026-09-04T10:30:00.000Z",
+  updatedAt: "2026-09-04T10:30:00.000Z",
+};
+
+function renderWithRequester(props: { ticketId?: number; onBack?: () => void } = {}) {
+  localStorage.setItem(
+    "toktickit_selected_requester",
+    JSON.stringify({
+      id: 1,
+      name: "Jennifer Anderson",
+      email: "jennifer.anderson@example.com",
+      active: true,
+    })
+  );
+
+  return render(
+    <RequesterProvider>
+      <TicketDetail ticketId={props.ticketId ?? 10} onBack={props.onBack ?? vi.fn()} />
+    </RequesterProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+});
+
+describe("TicketDetail Component (UI-07)", () => {
+  it("UI-07: renders complete ticket details, classification, and active attachments", async () => {
+    (api.fetchTicketDetail as ReturnType<typeof vi.fn>).mockResolvedValue(mockTicketData);
+
+    renderWithRequester();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("ticket-number")).toHaveTextContent("TKT-2026-000010");
+    });
+
+    expect(screen.getByText("VPN Connection drops every 15 minutes")).toBeInTheDocument();
+    expect(
+      screen.getByText("When working from home, the Cisco AnyConnect client disconnects abruptly.")
+    ).toBeInTheDocument();
+    expect(screen.getByText("High Priority")).toBeInTheDocument();
+    expect(screen.getByText("Network")).toBeInTheDocument();
+    expect(screen.getByText("VPN")).toBeInTheDocument();
+    expect(screen.getByText("Jennifer Anderson")).toBeInTheDocument();
+
+    // Attachment list check
+    expect(screen.getByText("vpn-log.pdf")).toBeInTheDocument();
+    expect(screen.getByTestId("download-attachment-101")).toBeInTheDocument();
+    expect(screen.getByTestId("remove-attachment-101")).toBeInTheDocument();
+  });
+
+  it("UI-07: opens soft-removal modal and enforces minimum 5 characters reason", async () => {
+    (api.fetchTicketDetail as ReturnType<typeof vi.fn>).mockResolvedValue(mockTicketData);
+    (api.removeAttachment as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: 101,
+      originalName: "vpn-log.pdf",
+      active: false,
+      removalReason: "Contains sensitive company IP address",
+      removedAt: "2026-09-04T11:00:00.000Z",
+    });
+
+    renderWithRequester();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("remove-attachment-101")).toBeInTheDocument();
+    });
+
+    // Click Remove button
+    fireEvent.click(screen.getByTestId("remove-attachment-101"));
+
+    // Modal appears
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Remove Attachment")).toBeInTheDocument();
+
+    const reasonInput = screen.getByLabelText(/Reason for Removal/i);
+    const confirmButton = screen.getByRole("button", { name: /Confirm Removal/i });
+
+    // Initially disabled because reason is empty
+    expect(confirmButton).toBeDisabled();
+
+    // Type 3 chars -> still disabled
+    fireEvent.change(reasonInput, { target: { value: "test" } });
+    expect(confirmButton).toBeDisabled();
+
+    // Type >= 5 chars -> enabled
+    fireEvent.change(reasonInput, {
+      target: { value: "Contains sensitive company IP address" },
+    });
+    expect(confirmButton).not.toBeDisabled();
+
+    // Submit removal
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(api.removeAttachment).toHaveBeenCalledWith(
+        101,
+        1,
+        "Contains sensitive company IP address"
+      );
+    });
+
+    // Modal closed and UI reflects Removed status
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Removed")).toBeInTheDocument();
+    expect(screen.getByText(/Contains sensitive company IP address/)).toBeInTheDocument();
+    expect(screen.getByText("Download unavailable")).toBeInTheDocument();
+  });
+
+  it("UI-07: handles attachment upload successfully", async () => {
+    (api.fetchTicketDetail as ReturnType<typeof vi.fn>).mockResolvedValue(mockTicketData);
+    (api.uploadAttachment as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: 102,
+      originalName: "screenshot.png",
+      sizeBytes: 150000,
+      mimeType: "image/png",
+      active: true,
+      removalReason: null,
+      removedAt: null,
+      createdAt: "2026-09-04T10:40:00.000Z",
+    });
+
+    renderWithRequester();
+
+    await waitFor(() => {
+      expect(screen.getByText("➕ Add Attachment")).toBeInTheDocument();
+    });
+
+    const fileInput = document.querySelector("#attachment-file-input") as HTMLInputElement;
+    expect(fileInput).toBeInTheDocument();
+
+    const testFile = new File(["dummy content"], "screenshot.png", { type: "image/png" });
+    fireEvent.change(fileInput, { target: { files: [testFile] } });
+
+    await waitFor(() => {
+      expect(api.uploadAttachment).toHaveBeenCalledWith(10, 1, testFile);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("screenshot.png")).toBeInTheDocument();
+    });
+  });
+
+  it("UI-07: rejects unsupported file types on client-side before API call", async () => {
+    (api.fetchTicketDetail as ReturnType<typeof vi.fn>).mockResolvedValue(mockTicketData);
+
+    renderWithRequester();
+
+    await waitFor(() => {
+      expect(screen.getByText("➕ Add Attachment")).toBeInTheDocument();
+    });
+
+    const fileInput = document.querySelector("#attachment-file-input") as HTMLInputElement;
+    const invalidFile = new File(["executable binary"], "virus.exe", {
+      type: "application/x-msdownload",
+    });
+
+    fireEvent.change(fileInput, { target: { files: [invalidFile] } });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Unsupported file type\. Permitted: JPG, PNG, WEBP, PDF\./i)
+      ).toBeInTheDocument();
+    });
+
+    expect(api.uploadAttachment).not.toHaveBeenCalled();
+  });
+
+  it("UI-07: triggers onBack when clicking '← Back to My Tickets'", async () => {
+    (api.fetchTicketDetail as ReturnType<typeof vi.fn>).mockResolvedValue(mockTicketData);
+    const onBackMock = vi.fn();
+
+    renderWithRequester({ onBack: onBackMock });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Back to My Tickets/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Back to My Tickets/i }));
+    expect(onBackMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("UI-07: renders friendly error state when ticket is not found or unauthorized", async () => {
+    (api.fetchTicketDetail as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("Ticket not found or unauthorized access")
+    );
+
+    renderWithRequester();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("ticket-detail-error")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Ticket Not Found or Unauthorized")).toBeInTheDocument();
+  });
+});

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -21,21 +21,21 @@ Testing follows a strict **Test-Driven Development (TDD)** and **Test-Driven Des
 | **TKT-05** | API | Ownership Isolation | `GET /api/tickets?requesterId=2` | 200 OK; does NOT include tickets belonging to Requester 1 | `server/tests/lab-02/my-tickets.test.ts` | Pass |
 | **TKT-06** | API | Search & Filter | `GET /api/tickets?requesterId=1&search=Laptop` | 200 OK; returns only tickets matching query | `server/tests/lab-02/my-tickets.test.ts` | Pass |
 | **TKT-07** | API | Pagination | `GET /api/tickets?requesterId=1&page=1&limit=2` | 200 OK; returns 2 items + correct pagination metadata | `server/tests/lab-02/my-tickets.test.ts` | Pass |
-| **TKT-08** | API | Ticket Detail (Owner) | `GET /api/tickets/1?requesterId=1` | 200 OK; returns full ticket details and attachments | `server/tests/lab-02/ticket-detail.test.ts` | Planned |
-| **TKT-09** | API | Detail Unauthorized | `GET /api/tickets/1?requesterId=2` | 404/403; access to another requester's ticket is rejected | `server/tests/lab-02/ticket-detail.test.ts` | Planned |
-| **ATT-01** | API | Upload Valid File | `POST /api/tickets/1/attachments` (valid PDF <= 5MB) | 201 Created; returns attachment record with `active: true` | `server/tests/lab-02/attachments.test.ts` | Planned |
-| **ATT-02** | API | Reject Invalid Type | `POST /api/tickets/1/attachments` (file `.exe`) | 400 Bad Request; unsupported type rejected | `server/tests/lab-02/attachments.test.ts` | Planned |
-| **ATT-03** | API | Reject Oversized File | `POST /api/tickets/1/attachments` (file > 5MB) | 400 Bad Request; file size limit error | `server/tests/lab-02/attachments.test.ts` | Planned |
-| **ATT-04** | API | Max 5 Attachments | Upload 6th attachment to ticket with 5 active | 400 Bad Request; maximum limit error | `server/tests/lab-02/attachments.test.ts` | Planned |
-| **ATT-05** | API | Soft-Remove File | `PATCH /api/attachments/1/remove` with valid reason | 200 OK; marked `active: false` with reason and timestamp | `server/tests/lab-02/attachments.test.ts` | Planned |
-| **ATT-06** | API | Block Removed Download | `GET /api/attachments/1/download` on soft-removed file | 410 Gone; download blocked | `server/tests/lab-02/attachments.test.ts` | Planned |
+| **TKT-08** | API | Ticket Detail (Owner) | `GET /api/tickets/1?requesterId=1` | 200 OK; returns full ticket details and attachments | `server/tests/lab-02/ticket-detail.test.ts` | Pass |
+| **TKT-09** | API | Detail Unauthorized | `GET /api/tickets/1?requesterId=2` | 404/403; access to another requester's ticket is rejected | `server/tests/lab-02/ticket-detail.test.ts` | Pass |
+| **ATT-01** | API | Upload Valid File | `POST /api/tickets/1/attachments` (valid PDF <= 5MB) | 201 Created; returns attachment record with `active: true` | `server/tests/lab-02/attachments.test.ts` | Pass |
+| **ATT-02** | API | Reject Invalid Type | `POST /api/tickets/1/attachments` (file `.exe`) | 400 Bad Request; unsupported type rejected | `server/tests/lab-02/attachments.test.ts` | Pass |
+| **ATT-03** | API | Reject Oversized File | `POST /api/tickets/1/attachments` (file > 5MB) | 400 Bad Request; file size limit error | `server/tests/lab-02/attachments.test.ts` | Pass |
+| **ATT-04** | API | Max 5 Attachments | Upload 6th attachment to ticket with 5 active | 400 Bad Request; maximum limit error | `server/tests/lab-02/attachments.test.ts` | Pass |
+| **ATT-05** | API | Soft-Remove File | `PATCH /api/attachments/1/remove` with valid reason | 200 OK; marked `active: false` with reason and timestamp | `server/tests/lab-02/attachments.test.ts` | Pass |
+| **ATT-06** | API | Block Removed Download | `GET /api/attachments/1/download` on soft-removed file | 410 Gone; download blocked | `server/tests/lab-02/attachments.test.ts` | Pass |
 | **UI-01** | UI | Requester Select | Render selector dropdown | Displays active requesters; clicking continue sets requester context | `client/tests/lab-02/RequesterSelect.test.tsx` | Pass |
 | **UI-02** | UI | Header Display | AppShell with active requester | Shows requester name & "Change Requester" button | `client/tests/lab-02/AppShell.test.tsx` | Pass |
 | **UI-03** | UI | Create Ticket Validation | Submit empty form | Displays field error messages; API not called | `client/tests/lab-02/CreateTicket.test.tsx` | Pass |
 | **UI-04** | UI | Create Ticket Success | Fill valid fields & submit | Shows busy state during submit, then success message with Ticket No | `client/tests/lab-02/CreateTicket.test.tsx` | Pass |
 | **UI-05** | UI | API Failure Resilience | Backend returns 500 on submit | Error banner shown; entered summary & description preserved | `client/tests/lab-02/CreateTicket.test.tsx` | Pass |
 | **UI-06** | UI | My Tickets Table | Render tickets list | Displays ticket number, summary, badges, and empty/no-results states | `client/tests/lab-02/MyTickets.test.tsx` | Pass |
-| **UI-07** | UI | Detail & Soft Removal | Open ticket detail, trigger remove | Prompts for removal reason modal; updates item to "Removed" | `client/tests/lab-02/TicketDetail.test.tsx` | Planned |
+| **UI-07** | UI | Detail & Soft Removal | Open ticket detail, trigger remove | Prompts for removal reason modal; updates item to "Removed" | `client/tests/lab-02/TicketDetail.test.tsx` | Pass |
 | **E2E-01**| E2E | Full Requester Flow | Select user → create ticket → verify in list → check details → switch user isolation | End-to-end user journey passes completely | `e2e/lab-02/requester-ticket-flow.spec.ts` | Planned |
 
 ---

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,11 +10,13 @@
       "dependencies": {
         "@prisma/client": "^5.22.0",
         "cors": "^2.8.5",
-        "express": "^4.21.2"
+        "express": "^4.21.2",
+        "multer": "^2.3.0"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
+        "@types/multer": "^2.2.0",
         "@types/node": "^22.10.2",
         "@types/supertest": "^6.0.2",
         "prisma": "^5.22.0",
@@ -1065,6 +1067,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/multer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-3U1troeqGV8Ntp7Q3klwf4zr23VEoqYVocYXaswm9+8z3O9UHDYAqLxjJ/h550iRADTjKdOdhhasXw6gD6kYtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.20.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
@@ -1272,6 +1284,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -1324,6 +1342,23 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -1422,6 +1457,21 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
       }
     },
     "node_modules/content-disposition": {
@@ -2077,6 +2127,25 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.3.0.tgz",
+      "integrity": "sha512-cjNbm3sttszgZeGfJR124D+jFEfkXCVAsoPBmFn9X7UxmDSFHWqE2CoEj0vrmSpuAFnqWR1Szcm9QTsiHr60Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.18",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
@@ -2287,6 +2356,20 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/rollup": {
@@ -2524,6 +2607,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/superagent": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
@@ -2693,6 +2793,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -2722,6 +2828,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/server/package.json
+++ b/server/package.json
@@ -11,15 +11,19 @@
     "prisma:seed": "tsx prisma/seed.ts",
     "test": "vitest run"
   },
-  "prisma": { "seed": "tsx prisma/seed.ts" },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
+  },
   "dependencies": {
     "@prisma/client": "^5.22.0",
     "cors": "^2.8.5",
-    "express": "^4.21.2"
+    "express": "^4.21.2",
+    "multer": "^2.3.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
+    "@types/multer": "^2.2.0",
     "@types/node": "^22.10.2",
     "@types/supertest": "^6.0.2",
     "prisma": "^5.22.0",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,6 +1,68 @@
-import express, { Request, Response } from "express";
+import express, { Request, Response, NextFunction } from "express";
 import cors from "cors";
+import path from "path";
+import fs from "fs";
+import crypto from "crypto";
+import { fileURLToPath } from "url";
+import multer from "multer";
 import { getPrisma } from "./prisma.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const UPLOADS_DIR = process.env.UPLOADS_DIR || path.resolve(__dirname, "../uploads");
+
+if (!fs.existsSync(UPLOADS_DIR)) {
+  fs.mkdirSync(UPLOADS_DIR, { recursive: true });
+}
+
+const storage = multer.diskStorage({
+  destination: (_req, _file, cb) => {
+    cb(null, UPLOADS_DIR);
+  },
+  filename: (_req, file, cb) => {
+    const ext = path.extname(file.originalname).toLowerCase();
+    const uniqueName = `${crypto.randomUUID()}${ext}`;
+    cb(null, uniqueName);
+  },
+});
+
+const ALLOWED_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "application/pdf",
+];
+
+const upload = multer({
+  storage,
+  limits: {
+    fileSize: 5 * 1024 * 1024, // 5MB
+  },
+  fileFilter: (_req, file, cb) => {
+    if (ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(new Error("Unsupported file type"));
+    }
+  },
+});
+
+function handleAttachmentUpload(req: Request, res: Response, next: NextFunction) {
+  upload.single("file")(req, res, (err: any) => {
+    if (err instanceof multer.MulterError) {
+      if (err.code === "LIMIT_FILE_SIZE") {
+        return res.status(400).json({ error: "File size exceeds 5MB limit" });
+      }
+      return res.status(400).json({ error: err.message });
+    } else if (err) {
+      if (err.message === "Unsupported file type") {
+        return res.status(400).json({ error: "Unsupported file type" });
+      }
+      return res.status(400).json({ error: err.message });
+    }
+    next();
+  });
+}
 
 export const app = express();
 
@@ -287,6 +349,271 @@ app.get("/api/tickets", async (req: Request, res: Response) => {
   } catch (error) {
     console.error("Failed to query tickets:", error);
     res.status(500).json({ error: "Failed to query tickets" });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Lab 2 — Issue 5: Helper function for uploaded file cleanup
+// ---------------------------------------------------------------------------
+function cleanupUploadedFile(file?: Express.Multer.File) {
+  if (file && file.path && fs.existsSync(file.path)) {
+    try {
+      fs.unlinkSync(file.path);
+    } catch (e) {
+      console.error("Failed to delete temp file:", e);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Lab 2 — Issue 5: Ticket Detail (GET /api/tickets/:id)
+// ---------------------------------------------------------------------------
+app.get("/api/tickets/:id", async (req: Request, res: Response) => {
+  try {
+    const prisma = getPrisma();
+    const ticketId = parseInt(req.params.id, 10);
+    const requesterIdStr = req.query.requesterId as string;
+
+    if (!requesterIdStr) {
+      res.status(400).json({ error: "requesterId is required" });
+      return;
+    }
+
+    const requesterId = parseInt(requesterIdStr, 10);
+    if (isNaN(ticketId) || ticketId <= 0 || isNaN(requesterId) || requesterId <= 0) {
+      res.status(400).json({ error: "Invalid ticket or requester ID" });
+      return;
+    }
+
+    const ticket = await prisma.ticket.findUnique({
+      where: { id: ticketId },
+      include: {
+        requester: { select: { id: true, name: true, email: true } },
+        category: { select: { id: true, name: true } },
+        relatedSystem: { select: { id: true, name: true } },
+        attachments: {
+          orderBy: { createdAt: "asc" },
+          select: {
+            id: true,
+            originalName: true,
+            sizeBytes: true,
+            mimeType: true,
+            active: true,
+            removalReason: true,
+            removedAt: true,
+            createdAt: true,
+          },
+        },
+      },
+    });
+
+    if (!ticket || ticket.requester.id !== requesterId) {
+      res.status(404).json({ error: "Ticket not found or unauthorized access" });
+      return;
+    }
+
+    res.json(ticket);
+  } catch (error) {
+    console.error("Failed to fetch ticket detail:", error);
+    res.status(500).json({ error: "Failed to fetch ticket detail" });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Lab 2 — Issue 5: Upload Attachment (POST /api/tickets/:id/attachments)
+// ---------------------------------------------------------------------------
+app.post(
+  "/api/tickets/:id/attachments",
+  handleAttachmentUpload,
+  async (req: Request, res: Response) => {
+    try {
+      const prisma = getPrisma();
+      const ticketId = parseInt(req.params.id, 10);
+      const requesterIdStr = req.body.requesterId;
+
+      if (!requesterIdStr) {
+        cleanupUploadedFile(req.file);
+        res.status(400).json({ error: "requesterId is required" });
+        return;
+      }
+
+      const requesterId = parseInt(requesterIdStr, 10);
+      if (isNaN(ticketId) || ticketId <= 0 || isNaN(requesterId) || requesterId <= 0) {
+        cleanupUploadedFile(req.file);
+        res.status(400).json({ error: "Invalid ticket or requester ID" });
+        return;
+      }
+
+      if (!req.file) {
+        res.status(400).json({ error: "File is required" });
+        return;
+      }
+
+      // Check ticket existence and ownership
+      const ticket = await prisma.ticket.findUnique({
+        where: { id: ticketId },
+        select: { id: true, requesterId: true },
+      });
+
+      if (!ticket || ticket.requesterId !== requesterId) {
+        cleanupUploadedFile(req.file);
+        res.status(404).json({ error: "Ticket not found or unauthorized" });
+        return;
+      }
+
+      // Check active attachments count (max 5)
+      const activeCount = await prisma.attachment.count({
+        where: { ticketId, active: true },
+      });
+
+      if (activeCount >= 5) {
+        cleanupUploadedFile(req.file);
+        res.status(400).json({ error: "Maximum 5 active attachments allowed per ticket" });
+        return;
+      }
+
+      const attachment = await prisma.attachment.create({
+        data: {
+          filename: req.file.filename,
+          originalName: req.file.originalname,
+          mimeType: req.file.mimetype,
+          sizeBytes: req.file.size,
+          active: true,
+          ticketId,
+        },
+        select: {
+          id: true,
+          originalName: true,
+          sizeBytes: true,
+          mimeType: true,
+          active: true,
+          createdAt: true,
+        },
+      });
+
+      res.status(201).json(attachment);
+    } catch (error) {
+      cleanupUploadedFile(req.file);
+      console.error("Failed to upload attachment:", error);
+      res.status(500).json({ error: "Failed to upload attachment" });
+    }
+  }
+);
+
+// ---------------------------------------------------------------------------
+// Lab 2 — Issue 5: Download Attachment (GET /api/attachments/:id/download)
+// ---------------------------------------------------------------------------
+app.get("/api/attachments/:id/download", async (req: Request, res: Response) => {
+  try {
+    const prisma = getPrisma();
+    const attachmentId = parseInt(req.params.id, 10);
+    const requesterIdStr = req.query.requesterId as string;
+
+    if (!requesterIdStr) {
+      res.status(400).json({ error: "requesterId is required" });
+      return;
+    }
+
+    const requesterId = parseInt(requesterIdStr, 10);
+    if (isNaN(attachmentId) || attachmentId <= 0 || isNaN(requesterId) || requesterId <= 0) {
+      res.status(400).json({ error: "Invalid attachment or requester ID" });
+      return;
+    }
+
+    const attachment = await prisma.attachment.findUnique({
+      where: { id: attachmentId },
+      include: {
+        ticket: { select: { requesterId: true } },
+      },
+    });
+
+    if (!attachment || attachment.ticket.requesterId !== requesterId) {
+      res.status(404).json({ error: "Attachment not found or unauthorized" });
+      return;
+    }
+
+    if (!attachment.active) {
+      res.status(410).json({ error: "This attachment has been removed and cannot be downloaded" });
+      return;
+    }
+
+    const filePath = path.join(UPLOADS_DIR, attachment.filename);
+    if (!fs.existsSync(filePath)) {
+      res.status(404).json({ error: "Attachment file not found on server" });
+      return;
+    }
+
+    res.setHeader("Content-Type", attachment.mimeType);
+    res.download(filePath, attachment.originalName);
+  } catch (error) {
+    console.error("Failed to download attachment:", error);
+    res.status(500).json({ error: "Failed to download attachment" });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Lab 2 — Issue 5: Soft-Remove Attachment (PATCH /api/attachments/:id/remove)
+// ---------------------------------------------------------------------------
+app.patch("/api/attachments/:id/remove", async (req: Request, res: Response) => {
+  try {
+    const prisma = getPrisma();
+    const attachmentId = parseInt(req.params.id, 10);
+    const { requesterId, reason } = req.body;
+
+    if (!requesterId) {
+      res.status(400).json({ error: "requesterId is required" });
+      return;
+    }
+
+    const parsedRequesterId = parseInt(String(requesterId), 10);
+    if (isNaN(attachmentId) || attachmentId <= 0 || isNaN(parsedRequesterId) || parsedRequesterId <= 0) {
+      res.status(400).json({ error: "Invalid attachment or requester ID" });
+      return;
+    }
+
+    const trimmedReason = typeof reason === "string" ? reason.trim() : "";
+    if (trimmedReason.length < 5) {
+      res.status(400).json({ error: "Removal reason must be at least 5 characters" });
+      return;
+    }
+
+    const attachment = await prisma.attachment.findUnique({
+      where: { id: attachmentId },
+      include: {
+        ticket: { select: { requesterId: true } },
+      },
+    });
+
+    if (!attachment || attachment.ticket.requesterId !== parsedRequesterId) {
+      res.status(404).json({ error: "Attachment not found or unauthorized" });
+      return;
+    }
+
+    if (!attachment.active) {
+      res.status(409).json({ error: "Attachment is already removed" });
+      return;
+    }
+
+    const updated = await prisma.attachment.update({
+      where: { id: attachmentId },
+      data: {
+        active: false,
+        removalReason: trimmedReason,
+        removedAt: new Date(),
+      },
+      select: {
+        id: true,
+        originalName: true,
+        active: true,
+        removalReason: true,
+        removedAt: true,
+      },
+    });
+
+    res.json(updated);
+  } catch (error) {
+    console.error("Failed to remove attachment:", error);
+    res.status(500).json({ error: "Failed to remove attachment" });
   }
 });
 

--- a/server/tests/lab-02/attachments.test.ts
+++ b/server/tests/lab-02/attachments.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import request from "supertest";
+import { app } from "../../src/app.js";
+
+describe("Attachment Lifecycle Endpoints (ATT-01 through ATT-06)", () => {
+  let ticketId: number;
+  let activeAttachmentId: number;
+  let removedAttachmentId: number;
+
+  beforeAll(async () => {
+    // Create a dedicated ticket owned by Requester 1
+    const res = await request(app)
+      .post("/api/tickets")
+      .send({
+        requesterId: 1,
+        categoryId: 2,
+        relatedSystemId: 7,
+        priority: "Medium",
+        summary: "Attachment Testing Ticket",
+        description: "Ticket created specifically for attachment lifecycle testing.",
+      });
+    ticketId = res.body.id;
+  });
+
+  // ATT-01: Upload valid attachment (PDF <= 5MB)
+  it("ATT-01: uploads a valid PDF attachment successfully", async () => {
+    const fakePdfBuffer = Buffer.from("%PDF-1.4 ... mock pdf content ...");
+    const res = await request(app)
+      .post(`/api/tickets/${ticketId}/attachments`)
+      .field("requesterId", 1)
+      .attach("file", fakePdfBuffer, {
+        filename: "test-document.pdf",
+        contentType: "application/pdf",
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty("id");
+    expect(res.body).toHaveProperty("originalName", "test-document.pdf");
+    expect(res.body).toHaveProperty("mimeType", "application/pdf");
+    expect(res.body).toHaveProperty("active", true);
+    expect(res.body).toHaveProperty("sizeBytes");
+    activeAttachmentId = res.body.id;
+  });
+
+  // ATT-02: Reject invalid MIME type
+  it("ATT-02: rejects unsupported file types (e.g. .exe)", async () => {
+    const exeBuffer = Buffer.from("MZ mock executable");
+    const res = await request(app)
+      .post(`/api/tickets/${ticketId}/attachments`)
+      .field("requesterId", 1)
+      .attach("file", exeBuffer, {
+        filename: "malware.exe",
+        contentType: "application/x-msdownload",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error", "Unsupported file type");
+  });
+
+  // ATT-03: Reject oversized file (> 5MB)
+  it("ATT-03: rejects files exceeding the 5MB limit", async () => {
+    // 5MB + 1KB buffer
+    const oversizedBuffer = Buffer.alloc(5 * 1024 * 1024 + 1024);
+    const res = await request(app)
+      .post(`/api/tickets/${ticketId}/attachments`)
+      .field("requesterId", 1)
+      .attach("file", oversizedBuffer, {
+        filename: "large-photo.jpg",
+        contentType: "image/jpeg",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error", "File size exceeds 5MB limit");
+  });
+
+  // Download active attachment (Owner)
+  it("downloads an active attachment successfully", async () => {
+    const res = await request(app).get(
+      `/api/attachments/${activeAttachmentId}/download?requesterId=1`
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers["content-disposition"]).toContain("test-document.pdf");
+  });
+
+  // ATT-05: Soft-remove attachment with valid reason
+  it("ATT-05: soft-removes an attachment with mandatory audit reason", async () => {
+    const res = await request(app)
+      .patch(`/api/attachments/${activeAttachmentId}/remove`)
+      .send({
+        requesterId: 1,
+        reason: "Uploaded file contained obsolete diagnostic logs",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("id", activeAttachmentId);
+    expect(res.body).toHaveProperty("active", false);
+    expect(res.body).toHaveProperty(
+      "removalReason",
+      "Uploaded file contained obsolete diagnostic logs"
+    );
+    expect(res.body).toHaveProperty("removedAt");
+    expect(res.body.removedAt).not.toBeNull();
+    removedAttachmentId = activeAttachmentId;
+  });
+
+  // Reject soft-remove with reason < 5 characters
+  it("rejects soft-removal when reason is shorter than 5 characters", async () => {
+    // First upload a new file to attempt removing
+    const buffer = Buffer.from("image content");
+    const uploadRes = await request(app)
+      .post(`/api/tickets/${ticketId}/attachments`)
+      .field("requesterId", 1)
+      .attach("file", buffer, {
+        filename: "screenshot.png",
+        contentType: "image/png",
+      });
+    const newAttId = uploadRes.body.id;
+
+    const res = await request(app)
+      .patch(`/api/attachments/${newAttId}/remove`)
+      .send({
+        requesterId: 1,
+        reason: "bad",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty(
+      "error",
+      "Removal reason must be at least 5 characters"
+    );
+  });
+
+  // Reject soft-remove on an already removed attachment (409 Conflict)
+  it("returns 409 Conflict when attempting to remove an already removed attachment", async () => {
+    const res = await request(app)
+      .patch(`/api/attachments/${removedAttachmentId}/remove`)
+      .send({
+        requesterId: 1,
+        reason: "Trying to remove again",
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toHaveProperty("error", "Attachment is already removed");
+  });
+
+  // ATT-06: Block download on soft-removed attachment (410 Gone)
+  it("ATT-06: returns 410 Gone when attempting to download a soft-removed attachment", async () => {
+    const res = await request(app).get(
+      `/api/attachments/${removedAttachmentId}/download?requesterId=1`
+    );
+    expect(res.status).toBe(410);
+    expect(res.body).toHaveProperty(
+      "error",
+      "This attachment has been removed and cannot be downloaded"
+    );
+  });
+
+  // Cross-requester security isolation checks
+  it("rejects cross-requester attachment download (returns 404)", async () => {
+    const res = await request(app).get(
+      `/api/attachments/${removedAttachmentId}/download?requesterId=2`
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects cross-requester attachment removal (returns 404)", async () => {
+    const res = await request(app)
+      .patch(`/api/attachments/${removedAttachmentId}/remove`)
+      .send({
+        requesterId: 2,
+        reason: "Unauthorized attempt",
+      });
+    expect(res.status).toBe(404);
+  });
+
+  // ATT-04: Maximum 5 active attachments limit
+  it("ATT-04: enforces a maximum of 5 active attachments per ticket", async () => {
+    // Create a fresh ticket for this test
+    const tRes = await request(app)
+      .post("/api/tickets")
+      .send({
+        requesterId: 1,
+        categoryId: 1,
+        relatedSystemId: 1,
+        priority: "Low",
+        summary: "Max 5 Attachments Ticket",
+        description: "Checking that the 6th active attachment upload is rejected.",
+      });
+    const freshTicketId = tRes.body.id;
+
+    // Upload 5 active attachments
+    for (let i = 1; i <= 5; i++) {
+      const upRes = await request(app)
+        .post(`/api/tickets/${freshTicketId}/attachments`)
+        .field("requesterId", 1)
+        .attach("file", Buffer.from(`file content ${i}`), {
+          filename: `doc-${i}.pdf`,
+          contentType: "application/pdf",
+        });
+      expect(upRes.status).toBe(201);
+    }
+
+    // Attempt to upload 6th attachment -> should fail with 400
+    const sixthRes = await request(app)
+      .post(`/api/tickets/${freshTicketId}/attachments`)
+      .field("requesterId", 1)
+      .attach("file", Buffer.from("sixth file content"), {
+        filename: "doc-6.pdf",
+        contentType: "application/pdf",
+      });
+
+    expect(sixthRes.status).toBe(400);
+    expect(sixthRes.body).toHaveProperty(
+      "error",
+      "Maximum 5 active attachments allowed per ticket"
+    );
+  });
+});

--- a/server/tests/lab-02/ticket-detail.test.ts
+++ b/server/tests/lab-02/ticket-detail.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import request from "supertest";
+import { app } from "../../src/app.js";
+
+describe("Ticket Detail Endpoints (TKT-08, TKT-09)", () => {
+  let requester1TicketId: number;
+  let requester2TicketId: number;
+
+  beforeAll(async () => {
+    // Create a ticket owned by Requester 1
+    const res1 = await request(app)
+      .post("/api/tickets")
+      .send({
+        requesterId: 1,
+        categoryId: 2,
+        relatedSystemId: 7,
+        priority: "High",
+        summary: "Ticket Detail Test for Requester 1",
+        description: "Testing retrieval of full ticket details including attachments and relations.",
+      });
+    requester1TicketId = res1.body.id;
+
+    // Create a ticket owned by Requester 2
+    const res2 = await request(app)
+      .post("/api/tickets")
+      .send({
+        requesterId: 2,
+        categoryId: 1,
+        relatedSystemId: 1,
+        priority: "Low",
+        summary: "Ticket Detail Test for Requester 2",
+        description: "Checking isolation barriers between different requesters.",
+      });
+    requester2TicketId = res2.body.id;
+  });
+
+  // TKT-08: GET /api/tickets/:id?requesterId=1 returns 200 with full details
+  it("TKT-08: returns full ticket detail and relations for the ticket owner", async () => {
+    const res = await request(app).get(`/api/tickets/${requester1TicketId}?requesterId=1`);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("id", requester1TicketId);
+    expect(res.body).toHaveProperty("ticketNumber");
+    expect(res.body.ticketNumber).toMatch(/^TKT-\d{4}-\d{6}$/);
+    expect(res.body).toHaveProperty("summary", "Ticket Detail Test for Requester 1");
+    expect(res.body).toHaveProperty("description");
+    expect(res.body).toHaveProperty("priority", "High");
+    expect(res.body).toHaveProperty("status", "New");
+    expect(res.body).toHaveProperty("requester");
+    expect(res.body.requester).toHaveProperty("id", 1);
+    expect(res.body).toHaveProperty("category");
+    expect(res.body.category).toHaveProperty("id", 2);
+    expect(res.body).toHaveProperty("relatedSystem");
+    expect(res.body.relatedSystem).toHaveProperty("id", 7);
+    expect(res.body).toHaveProperty("attachments");
+    expect(Array.isArray(res.body.attachments)).toBe(true);
+  });
+
+  // TKT-09: GET /api/tickets/:id?requesterId=2 rejects unauthorized cross-requester access
+  it("TKT-09: returns 404 unauthorized when another requester tries to view the ticket", async () => {
+    const res = await request(app).get(`/api/tickets/${requester1TicketId}?requesterId=2`);
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty("error");
+    expect(res.body.error).toMatch(/unauthorized|not found/i);
+  });
+
+  it("returns 400 Bad Request when requesterId is missing", async () => {
+    const res = await request(app).get(`/api/tickets/${requester1TicketId}`);
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty("error", "requesterId is required");
+  });
+
+  it("returns 404 Not Found for non-existent ticket ID", async () => {
+    const res = await request(app).get("/api/tickets/999999?requesterId=1");
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty("error");
+  });
+});


### PR DESCRIPTION
## Summary
Implements Issue 5: Requester Ticket Detail view and Attachment lifecycle with audit-compliant soft-removal under strict ownership isolation and the Zen Green Design System.

## Changes
- **Backend & Attachments (`server/src/app.ts`):**
  - Integrated `multer` handling multipart uploads stored in `server/uploads/` with UUID filenames.
  - Enforced file constraints: permitted MIME types (`image/jpeg`, `image/png`, `image/webp`, `application/pdf`), maximum size `5 MB`, and maximum `5 active attachments` per ticket.
  - Implemented `GET /api/tickets/:id?requesterId=...` (ownership check returning 404 for cross-requester access; returns ticket relations and attachments).
  - Implemented `POST /api/tickets/:id/attachments` (validates ticket ownership, enforces 5 active limit, saves file).
  - Implemented `GET /api/attachments/:id/download?requesterId=...` (returns `410 Gone` if attachment is soft-removed; streams file if active).
  - Implemented `PATCH /api/attachments/:id/remove` (enforces mandatory removal reason $\ge 5$ chars, marks `active: false`, records `removedAt` and `removalReason`).
- **Frontend UI (`client/src/`):**
  - Added API client functions and TypeScript interfaces in `client/src/api.ts`.
  - Created `TicketDetail.tsx` adhering to Zen Green Design System with Back button, classification grid, description, attachment counter, download links, and soft-removal modal dialog.
  - Connected ticket selection navigation in `AppShell.tsx`.
- **Automated Tests:**
  - Added `server/tests/lab-02/ticket-detail.test.ts` (TKT-08, TKT-09).
  - Added `server/tests/lab-02/attachments.test.ts` (ATT-01 through ATT-06).
  - Added `client/tests/lab-02/TicketDetail.test.tsx` (UI-07).
  - Updated `docs/lab-02/tests.md` with passing test evidence.

## Test Evidence
- Server vitest: 8 test files, 34 tests passed.
- Client vitest: 6 test files, 22 tests passed.
- Builds: `tsc` and `vite build` completed with 0 errors.

Closes #5
